### PR TITLE
(Feature) Show rows left of unbonding period for unbonding users

### DIFF
--- a/src/Components/AccountSummary/AccountSummaryHome/Blocks/Reward/RewardDescriptionDelegator.js
+++ b/src/Components/AccountSummary/AccountSummaryHome/Blocks/Reward/RewardDescriptionDelegator.js
@@ -8,7 +8,7 @@ const RewardDescriptionDelegator = props => {
 
   const description = props => {
     const { summary } = props
-    const { status, delegateCalledReward, delegateAddress, startRound } = summary
+    let { status, delegateCalledReward, delegateAddress, startRound, roundsLeft } = summary
 
     const delegateAddressUrl = `https://explorer.livepeer.org/accounts/${delegateAddress}/transcoding`
     const delegateAddressTruncated = truncateStringInTheMiddle(delegateAddress)
@@ -39,7 +39,10 @@ const RewardDescriptionDelegator = props => {
               </>
             ),
             Pending: `A delegator enters the Pending state when it bonds from the Unbonded state.`,
-            Unbonding: `You still have to wait a few moments to get finally Unbonded.`,
+            Unbonding:
+              `You still have ` +
+              roundsLeft +
+              ` round(s) left in the unbonding period. Each round lasts roughly one day..`,
             Unbonded: (
               <>
                 You are not bonded to any delegate, therefore you are not earning LPT from the token

--- a/src/Components/AccountSummary/AccountSummaryHome/Blocks/Reward/RewardDescriptionDelegator.js
+++ b/src/Components/AccountSummary/AccountSummaryHome/Blocks/Reward/RewardDescriptionDelegator.js
@@ -8,7 +8,7 @@ const RewardDescriptionDelegator = props => {
 
   const description = props => {
     const { summary } = props
-    let { status, delegateCalledReward, delegateAddress, startRound, roundsLeft } = summary
+    let { status, delegateCalledReward, delegateAddress, startRound, roundsUntilUnbonded } = summary
 
     const delegateAddressUrl = `https://explorer.livepeer.org/accounts/${delegateAddress}/transcoding`
     const delegateAddressTruncated = truncateStringInTheMiddle(delegateAddress)
@@ -41,7 +41,7 @@ const RewardDescriptionDelegator = props => {
             Pending: `A delegator enters the Pending state when it bonds from the Unbonded state.`,
             Unbonding:
               `You still have ` +
-              roundsLeft +
+              roundsUntilUnbonded +
               ` round(s) left in the unbonding period. Each round lasts roughly one day..`,
             Unbonded: (
               <>

--- a/src/Components/AccountSummary/AccountSummaryHome/Blocks/Reward/RewardDescriptionDelegator.js
+++ b/src/Components/AccountSummary/AccountSummaryHome/Blocks/Reward/RewardDescriptionDelegator.js
@@ -42,7 +42,7 @@ const RewardDescriptionDelegator = props => {
             Unbonding:
               `You still have ` +
               roundsUntilUnbonded +
-              ` round(s) left in the unbonding period. Each round lasts roughly one day..`,
+              ` round(s) left in the unbonding period. Each round lasts roughly one day.`,
             Unbonded: (
               <>
                 You are not bonded to any delegate, therefore you are not earning LPT from the token


### PR DESCRIPTION
Closes #53 
Let the users in unbonding state to now how much rounds they need to be on unbonded state again