### PR TITLE
Shorten format for delegate address and link to livepeer page

### DIFF
--- a/src/Components/Common/Card/index.js
+++ b/src/Components/Common/Card/index.js
@@ -28,10 +28,14 @@ const Body = styled.div`
 `
 
 const Card = props => {
-  const { title, children, titleAlign = 'left', bodyAlign, ...restProps } = props
+  const { title, children, titleAlign = 'left', bodyAlign, tooltip, ...restProps } = props
   return (
     <CardStyled {...restProps}>
-      {title ? <Title titleAlign={titleAlign}>{title}</Title> : null}
+      {title ? (
+        <Title title={tooltip ? tooltip : ''} titleAlign={titleAlign}>
+          {title}
+        </Title>
+      ) : null}
       <Body bodyAlign={bodyAlign}>{children}</Body>
     </CardStyled>
   )

--- a/src/Components/TranscoderInfo/index.js
+++ b/src/Components/TranscoderInfo/index.js
@@ -5,7 +5,7 @@ import IconInactive from './img/IconInactive'
 import StrippedList, { TR, TD } from '../Common/StrippedList'
 import styled from 'styled-components'
 import SmallLoadingCard from '../Common/SmallLoadingCard'
-import { decimalPlaces } from '../../Utils'
+import { truncateStringInTheMiddle, decimalPlaces } from '../../Utils'
 
 const Status = styled.h3`
   align-items: center;
@@ -34,6 +34,9 @@ const TDTitle = styled(TD)`
 
 const TDData = styled(TD)`
   text-align: right;
+`
+const A = styled.a`
+  color: black;
 `
 
 const TranscoderInfo = props => {
@@ -77,8 +80,16 @@ const TranscoderInfo = props => {
     ],
   }
 
+  const delegateAddressUrl = `https://explorer.livepeer.org/accounts/${delegateData.address}/transcoding`
+
+  const title = (
+    <A href={delegateAddressUrl} target="_blank" rel="noopener noreferrer">
+      {truncateStringInTheMiddle(delegateData.address)}
+    </A>
+  )
+
   const card = (
-    <Card title={delegateData.address} titleAlign="center" {...restProps}>
+    <Card title={title} tooltip={delegateData.address} titleAlign="center" {...restProps}>
       <Status>
         {isActive ? (
           <>


### PR DESCRIPTION
Connects to #90 

### Includes
- Delegate address must be showed with shorten format like the design, add a tooltip with complete number
- Add a link to explorer livepeer page onto Delegate address

![Screenshot_20190802_112234](https://user-images.githubusercontent.com/1144028/62376791-dab9dd80-b517-11e9-97f7-a48b6128e3ad.png)
