### PR TITLE
(Feature) Fix metamask account change

### DIFF
--- a/src/Components/Common/Hoc/Web3Provider/index.js
+++ b/src/Components/Common/Hoc/Web3Provider/index.js
@@ -167,7 +167,7 @@ class Web3Provider extends Component {
 
     // We subscribe to the event that detects if the user has changed the account
     window.ethereum.on('accountsChanged', accounts => {
-      return this.accountChangedCallback(web3Instance, accounts)
+      window.location.reload()
     })
     // We subscribe to the event that detects if the user has changed the network
     window.ethereum.on('networkChanged', network => {


### PR DESCRIPTION
No issue related

If the user changes the metamask account, now the page reloads