### PR TITLE
(Hotfix) Fixs non-updated local subscriber data on subscription update

### DIFF
--- a/src/Components/Common/Hoc/SubscriberProvider/index.js
+++ b/src/Components/Common/Hoc/SubscriberProvider/index.js
@@ -385,6 +385,10 @@ class SubscriberProvider extends Component {
       logger.log('Updating subscriber with data: ', subscriptionData)
       const subscriberId = subscriptionData.id
       await axios.put(`/subscribers/${subscriberId}`, subscriptionData)
+      const newSubscriptionData = {
+        ...subscriptionData,
+      }
+      this.updateSubscriberData(newSubscriptionData)
     } catch (err) {
       logger.log('Exception on updateUserSubscription')
       throw err


### PR DESCRIPTION
No issue related

Now the `subscriberProvider` updates the local subscriber data on subscription update