### PR TITLE
(Feature) UI feedback

### DIFF
--- a/src/Components/AccountSummaryHome/index.js
+++ b/src/Components/AccountSummaryHome/index.js
@@ -3,7 +3,6 @@ import RewardSubscribeText from '../RewardSubscribeText'
 import StatusDelegate from '../StatusDelegate'
 import StatusDelegator from '../StatusDelegator'
 import Wallet from '../Wallet'
-import PageTitle from '../Common/PageTitle'
 import TranscoderInfo from '../TranscoderInfo'
 import EarnedRewards from '../EarnedRewards'
 import styled from 'styled-components'
@@ -53,7 +52,6 @@ const AccountSummaryHome = props => {
       </MultiBlocksRowTop>
       {!isDelegate && summary.status === 'Bonded' && (
         <>
-          <PageTitle>My Delegate</PageTitle>
           <MultiBlocksRow>
             <TranscoderInfo myDelegateData={myDelegateData} subscriberData={subscriberData} summaryData={summaryData} />
             <EarnedRewards earnedRewardData={earnedRewardData} />

--- a/src/Components/Common/Footer/index.js
+++ b/src/Components/Common/Footer/index.js
@@ -33,7 +33,7 @@ function Footer({ ...props }) {
   return (
     <FooterStyled>
       <Text>
-        {1900 + new Date().getYear()} <a href="https://www.protofire.io">Protofire.io.</a>
+        {1900 + new Date().getYear()} <a href="https://www.protofire.io">Built by Protofire.io.</a>
         <a href="https://github.com/protofire/livepeer-alerts-frontend">
           <IconGithub />
         </a>

--- a/src/Components/EarnedRewards/index.js
+++ b/src/Components/EarnedRewards/index.js
@@ -4,7 +4,7 @@ import StrippedList, { TR, TD, TH } from '../Common/StrippedList'
 import Tooltip from '../Common/Tooltip'
 import styled from 'styled-components'
 import SmallLoadingCard from '../Common/SmallLoadingCard'
-import { decimalPlaces } from '../../Utils'
+import { toFixedDecimals } from '../../Utils'
 
 const Description = styled.h3`
   display: flex;
@@ -33,39 +33,40 @@ const THData = styled(TH)`
 
 const EarnedRewards = props => {
   const { earnedRewardData, ...restProps } = props
-
   const earnedData = [
     {
       round: 'Next',
-      lpt: decimalPlaces(earnedRewardData && earnedRewardData.nextReward && earnedRewardData.nextReward.delegateReward),
-      cut: decimalPlaces(
+      lpt: toFixedDecimals(
+        earnedRewardData && earnedRewardData.nextReward && earnedRewardData.nextReward.delegateReward,
+      ),
+      cut: toFixedDecimals(
         earnedRewardData && earnedRewardData.nextReward && earnedRewardData.nextReward.delegatorReward,
       ),
     },
     {
       round: 'Last',
-      lpt: decimalPlaces(
+      lpt: toFixedDecimals(
         earnedRewardData && earnedRewardData.lastRoundReward && earnedRewardData.lastRoundReward.delegateReward,
       ),
-      cut: decimalPlaces(
+      cut: toFixedDecimals(
         earnedRewardData && earnedRewardData.lastRoundReward && earnedRewardData.lastRoundReward.delegatorReward,
       ),
     },
     {
       round: 'Last 7',
-      lpt: decimalPlaces(
+      lpt: toFixedDecimals(
         earnedRewardData && earnedRewardData.last7RoundsReward && earnedRewardData.last7RoundsReward.delegateReward,
       ),
-      cut: decimalPlaces(
+      cut: toFixedDecimals(
         earnedRewardData && earnedRewardData.last7RoundsReward && earnedRewardData.last7RoundsReward.delegatorReward,
       ),
     },
     {
       round: 'Last 30',
-      lpt: decimalPlaces(
+      lpt: toFixedDecimals(
         earnedRewardData && earnedRewardData.last30RoundsReward && earnedRewardData.last30RoundsReward.delegateReward,
       ),
-      cut: decimalPlaces(
+      cut: toFixedDecimals(
         earnedRewardData && earnedRewardData.last30RoundsReward && earnedRewardData.last30RoundsReward.delegatorReward,
       ),
     },
@@ -74,7 +75,7 @@ const EarnedRewards = props => {
   const tableHead = (
     <TR>
       <TH>Round</TH>
-      <THData>LPT</THData>
+      <THData>Delegate</THData>
       <THData>Your Cut</THData>
     </TR>
   )

--- a/src/Components/HomeCard/index.js
+++ b/src/Components/HomeCard/index.js
@@ -96,7 +96,7 @@ const ButtonStyled = styled(Button)`
 
 class HomeCard extends React.Component {
   render() {
-    const { onClick, onDemoClick } = this.props
+    const { onClick } = this.props
     const demoAddress = process.env.REACT_APP_DEMO_ADDRESS
 
     let demoBtnDisabled = typeof demoAddress === 'undefined' || demoAddress.length === 0
@@ -138,9 +138,6 @@ class HomeCard extends React.Component {
         <ButtonsContainer>
           <ButtonStyled onClick={onClick} type="primary">
             Get started
-          </ButtonStyled>
-          <ButtonStyled onClick={onDemoClick} disabled={demoBtnDisabled} type="secondary">
-            Demo
           </ButtonStyled>
         </ButtonsContainer>
       </CardHome>

--- a/src/Components/Reward/RewardDescriptionDelegator.js
+++ b/src/Components/Reward/RewardDescriptionDelegator.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { truncateStringInTheMiddle } from '../../Utils'
 import { Emoji } from 'emoji-mart'
 import styled from 'styled-components'
 
@@ -32,10 +31,7 @@ const A = styled.a`
 const RewardDescriptionDelegator = props => {
   const description = props => {
     const { summary } = props
-    let { status, delegateCalledReward, delegateAddress, startRound, roundsUntilUnbonded } = summary
-
-    const delegateAddressUrl = `https://explorer.livepeer.org/accounts/${delegateAddress}/transcoding`
-    const delegateAddressTruncated = truncateStringInTheMiddle(delegateAddress)
+    let { status, delegateCalledReward, roundsUntilUnbonded } = summary
 
     let bondedDescription
 
@@ -46,16 +42,7 @@ const RewardDescriptionDelegator = props => {
     }
 
     return {
-      Bonded: (
-        <>
-          You are bonded to delegate{' '}
-          <A href={delegateAddressUrl} title={delegateAddress} target="_blank" rel="noopener noreferrer">
-            {delegateAddressTruncated}
-          </A>{' '}
-          since round #{startRound}.<br />
-          {bondedDescription}
-        </>
-      ),
+      Bonded: <>{bondedDescription}</>,
       Pending: `A delegator enters the Pending state when it bonds from the Unbonded state.`,
       Unbonding:
         `You still have ` +

--- a/src/Components/StatusDelegator/index.js
+++ b/src/Components/StatusDelegator/index.js
@@ -52,7 +52,7 @@ const StatusDelegator = props => {
   let content = summary.loadingSummary ? (
     <SmallLoadingCard show={true} message={'Loading user status...'} />
   ) : (
-    <Card title="Status">
+    <Card title="Your Status">
       <Title>
         {statusUppercase} <Tooltip description={statusToolTip} />
       </Title>

--- a/src/Components/TranscoderInfo/index.js
+++ b/src/Components/TranscoderInfo/index.js
@@ -49,6 +49,7 @@ const TranscoderInfo = props => {
   const address = summaryData && summaryData.delegator && summaryData.delegator.delegateAddress
   const missedRewardCalls = (myDelegateData && myDelegateData.last30RoundsMissedRewardCalls) || 0
   const rewardCut = (myDelegateData && myDelegateData.rewardCut) || 0
+  const rewardCutPercentage = rewardCut / 10000
 
   const roi = (myDelegateData && myDelegateData.roiAbs) || 0
   const roiEvery1000 = (myDelegateData && myDelegateData.roiPercent) || 0
@@ -63,19 +64,19 @@ const TranscoderInfo = props => {
       },
       {
         title: 'Reward Cut',
-        data: `${decimalPlaces(rewardCut)}%`,
+        data: `${decimalPlaces(rewardCutPercentage)}%`,
       },
       {
         title: 'Missed Reward Calls',
         data: `${missedRewardCalls}/30`,
       },
       {
-        title: 'Return of investment',
+        title: 'ROI / round for 1000 LPT',
         data: `${decimalPlaces(roi)}`,
       },
       {
-        title: 'Return of investment (%)',
-        data: `${decimalPlaces(roiEvery1000)}`,
+        title: 'ROI (%)',
+        data: `${decimalPlaces(roiEvery1000)}%`,
       },
     ],
   }

--- a/src/Utils/index.js
+++ b/src/Utils/index.js
@@ -8,6 +8,10 @@ const truncateStringInTheMiddle = (str, strLength = 41, strPositionStart = 8, st
   return str
 }
 
+const toFixedDecimals = (x = 0, decimals = 4) => {
+  return new BigNumber(x).toFixed(decimals)
+}
+
 const decimalPlaces = (x = 0, decimals = 4) => {
   return new BigNumber(x).decimalPlaces(decimals).toString()
 }
@@ -19,4 +23,4 @@ const isFrequencySupported = newFrequency => {
   return SUPPORTED_FREQUENCIES.includes(newFrequency)
 }
 
-export { truncateStringInTheMiddle, decimalPlaces, isFrequencySupported }
+export { truncateStringInTheMiddle, decimalPlaces, isFrequencySupported, toFixedDecimals }


### PR DESCRIPTION
Related to #100 

## Description
- Remove button DEMO
- Change the title "Status" by "Your Status Bonded
- Delete title "Your Delegate" 
- Change "Return of Investment" by "ROI / round for 1000 LPT"
- Change "Return of Investment (%)" by "ROI (%)" 
- The value of ROI (%) are showed with %
- Force to show 4 digits always in earnings
- Changes "2019 Protofire.io" by "2019 Built by Protofire.io"
- Just left the line "The delegate has successfully claimed the last inflationary token rewards."

### Looks like this now
![image](https://user-images.githubusercontent.com/21086218/62492792-eae6ec80-b7a5-11e9-9989-99d8a368686f.png)
![image](https://user-images.githubusercontent.com/21086218/62492779-e1f61b00-b7a5-11e9-99e5-6212eba77fb5.png)
