### PR TITLE
(Hotfix) Fees format

### DIFF
--- a/src/Components/Common/KeyValue/KeyValueToolTiped/index.js
+++ b/src/Components/Common/KeyValue/KeyValueToolTiped/index.js
@@ -1,0 +1,69 @@
+import ReactTooltip from 'react-tooltip'
+import styled from 'styled-components'
+import React from 'react'
+const TooltipPopup = styled.div`
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  outline: none;
+  position: relative;
+  white-space: normal;
+
+  > svg {
+    margin-left: 5px;
+
+    path {
+      fill: ${props => props.theme.colors.lightText};
+    }
+
+    &:hover {
+      path {
+        fill: ${props => props.theme.colors.darkGray};
+      }
+    }
+  }
+
+  .reactTooltip {
+    background-color: #000;
+    color: #fff;
+    max-width: 280px;
+    opacity: 1;
+    text-align: left;
+
+    &.place-left:after {
+      border-left-color: #000;
+    }
+
+    &.place-right:after {
+      border-right-color: #000;
+    }
+
+    &.place-top:after {
+      border-top-color: #000;
+    }
+
+    &.place-bottom:after {
+      border-bottom-color: #000;
+    }
+
+    .multi-line {
+      text-align: left;
+    }
+  }
+`
+
+const KeyValueToolTiped = props => {
+  const { value, tooltipText } = props
+  return (
+    <>
+      <a data-tip data-for="textKey">
+        {value}
+      </a>
+      <ReactTooltip id="textKey" className="TooltipPopup">
+        <span>{tooltipText}</span>
+      </ReactTooltip>
+    </>
+  )
+}
+
+export default KeyValueToolTiped

--- a/src/Components/Common/KeyValue/index.js
+++ b/src/Components/Common/KeyValue/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import Tooltip from '../Tooltip'
+import KeyValueToolTiped from './KeyValueToolTiped'
 
 const KeyValueStyled = styled.div`
   border-top: 1px solid ${props => props.theme.colors.borderColor};
@@ -53,7 +54,13 @@ const KeyValue = props => {
       {items.map((item, index) => {
         return (
           <Item key={index}>
-            <Value>{item.data}</Value>
+            <Value>
+              {item.tooltipDataText ? (
+                <KeyValueToolTiped value={item.data} tooltipText={item.tooltipDataText} />
+              ) : (
+                item.data
+              )}
+            </Value>
             <Title>
               {item.text}
               {item.tooltip ? <Tooltip description={item.tooltip} /> : null}

--- a/src/Components/Common/KeyValue/index.js
+++ b/src/Components/Common/KeyValue/index.js
@@ -23,7 +23,7 @@ const Item = styled.div`
   }
 `
 
-const Value = styled.p`
+const Value = styled.div`
   color: ${props => props.theme.colors.secondaryText};
   font-size: 20px;
   font-weight: 400;

--- a/src/Components/Common/KeyValue/index.js
+++ b/src/Components/Common/KeyValue/index.js
@@ -55,15 +55,15 @@ const KeyValue = props => {
         return (
           <Item key={index}>
             <Value>
-              {item.tooltipDataText ? (
-                <KeyValueToolTiped value={item.data} tooltipText={item.tooltipDataText} />
+              {item.tooltip && item.tooltip.value ? (
+                <KeyValueToolTiped value={item.data} tooltipText={item.tooltip.value} />
               ) : (
                 item.data
               )}
             </Value>
             <Title>
               {item.text}
-              {item.tooltip ? <Tooltip description={item.tooltip} /> : null}
+              {item.tooltip ? <Tooltip description={item.tooltip.text} /> : null}
             </Title>
           </Item>
         )

--- a/src/Components/HomeCard/index.js
+++ b/src/Components/HomeCard/index.js
@@ -80,7 +80,7 @@ const CheckboxStyled = styled(Checkbox)`
   margin: 0 10px 0 0;
 `
 
-const WarningText = styled.p`
+const WarningText = styled.div`
   color: #333;
   font-size: 12px;
   font-weight: 500;

--- a/src/Components/StatusDelegator/index.js
+++ b/src/Components/StatusDelegator/index.js
@@ -30,11 +30,9 @@ const StatusDelegator = props => {
   const { totalStakeInLPT, fees, status } = summary
   let feesInETH = 0
   // Formats fees from wei to ETH
-  if(fees) {
+  if (fees) {
     feesInETH = web3.utils.fromWei(fees.toString(), 'ether')
-    feesInETH = toFixedDecimals(feesInETH, 2)
   }
-
 
   const tableData = [
     {
@@ -43,10 +41,10 @@ const StatusDelegator = props => {
       tooltip: toolTipsTexts.TOTAL_STAKE_TOOLTIP,
     },
     {
-      data: feesInETH,
+      data: toFixedDecimals(feesInETH, 2),
       text: 'ETH Earning fees',
       tooltip: toolTipsTexts.EARNING_FEES_TOOLTIP,
-      tooltipDataText: fees,
+      tooltipDataText: feesInETH,
     },
   ]
   const toolTips = {

--- a/src/Components/StatusDelegator/index.js
+++ b/src/Components/StatusDelegator/index.js
@@ -38,13 +38,17 @@ const StatusDelegator = props => {
     {
       data: totalStakeInLPT,
       text: 'LPT Staked',
-      tooltip: toolTipsTexts.TOTAL_STAKE_TOOLTIP,
+      tooltip: {
+        text: toolTipsTexts.TOTAL_STAKE_TOOLTIP,
+      },
     },
     {
       data: toFixedDecimals(feesInETH, 2),
       text: 'ETH Earning fees',
-      tooltip: toolTipsTexts.EARNING_FEES_TOOLTIP,
-      tooltipDataText: feesInETH,
+      tooltip: {
+        text: toolTipsTexts.EARNING_FEES_TOOLTIP,
+        value: `${feesInETH} ETH`,
+      },
     },
   ]
   const toolTips = {

--- a/src/Components/StatusDelegator/index.js
+++ b/src/Components/StatusDelegator/index.js
@@ -5,6 +5,7 @@ import KeyValue from '../Common/KeyValue'
 import styled from 'styled-components'
 import Tooltip from '../Common/Tooltip'
 import SmallLoadingCard from '../Common/SmallLoadingCard'
+import { toFixedDecimals } from '../../Utils'
 
 const Title = styled.h3`
   align-items: center;
@@ -25,8 +26,16 @@ const KeyValueStyled = styled(KeyValue)`
 `
 
 const StatusDelegator = props => {
-  const { summary } = props
+  const { summary, web3 } = props
   const { totalStakeInLPT, fees, status } = summary
+  let feesInETH = 0
+  // Formats fees from wei to ETH
+  if(fees) {
+    feesInETH = web3.utils.fromWei(fees.toString(), 'ether')
+    feesInETH = toFixedDecimals(feesInETH, 2)
+  }
+
+
   const tableData = [
     {
       data: totalStakeInLPT,
@@ -34,9 +43,10 @@ const StatusDelegator = props => {
       tooltip: toolTipsTexts.TOTAL_STAKE_TOOLTIP,
     },
     {
-      data: fees,
+      data: feesInETH,
       text: 'ETH Earning fees',
       tooltip: toolTipsTexts.EARNING_FEES_TOOLTIP,
+      tooltipDataText: fees,
     },
   ]
   const toolTips = {
@@ -48,7 +58,6 @@ const StatusDelegator = props => {
 
   const statusUppercase = status.toUpperCase()
   const statusToolTip = toolTips[statusUppercase]
-
   let content = summary.loadingSummary ? (
     <SmallLoadingCard show={true} message={'Loading user status...'} />
   ) : (


### PR DESCRIPTION
Closes [#148](https://github.com/protofire/livepeer-alerts-backend/issues/148)
## Description
- The fee shares of the delegator were displayed in `WEI` but the card was displaying `ETH`
- Now we convert the value to `ETH` and we display a tooltip with the `WETH` value

### Looks like this now:
![image](https://user-images.githubusercontent.com/21086218/64890981-1ed7ec00-d647-11e9-8d5a-1a19e2e3b94d.png)
